### PR TITLE
Fixed infinite recursion related to collections

### DIFF
--- a/src/main/java/com/godaddy/logging/messagebuilders/StringMessageBuilder.java
+++ b/src/main/java/com/godaddy/logging/messagebuilders/StringMessageBuilder.java
@@ -73,7 +73,7 @@ public class StringMessageBuilder extends LoggerMessageBuilder<String> {
         }
 
         try {
-            buildMessage(currentObject, new ArrayList<>(), "", 0);
+            buildMessage(currentObject, new ArrayList<>(), "");
 
             trimLastSeparator();
         }


### PR DESCRIPTION
This addresses #10. Objects within a collection were instantiating new JsonMessageBuilders with the current recursive level being set to 0. It's because of this that collections were not satisfying the recursive level requirements and could go infinitely deep.