### PR TITLE
Updated plugins and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,19 +33,19 @@
     </developers>
 
     <properties>
-        <slf4j.version>1.7.10</slf4j.version>
-        <lombok.version>1.16.2</lombok.version>
-        <reflectasm.version>1.10.0</reflectasm.version>
-        <guava.version>18.0</guava.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <lombok.version>1.16.20</lombok.version>
+        <reflectasm.version>1.11.3</reflectasm.version>
+        <guava.version>22.0</guava.version>
         <logback.version>1.2.3</logback.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>2.13.0</mockito.version>
         <junit.version>4.12</junit.version>
         <java.version>1.8</java.version>
-        <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>
-        <maven.source.plugin.version>2.4</maven.source.plugin.version>
-        <maven.surefire.report.plugin.version>2.14</maven.surefire.report.plugin.version>
-        <maven.surefire.plugin.version>2.14</maven.surefire.plugin.version>
-        <logstash.version>4.10</logstash.version>
+        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
+        <maven.surefire.report.plugin.version>2.20.1</maven.surefire.report.plugin.version>
+        <maven.surefire.plugin.version>2.20.1</maven.surefire.plugin.version>
+        <logstash.version>4.11</logstash.version>
     </properties>
     
     <distributionManagement>
@@ -105,7 +105,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Updated the following dependency versions:
- guava: 18.0 to 22.0
- logback: 1.1.3 to 1.2.3
- lombok: 1.16.2 to 1.16.20
- reflactasm: 1.10.0 to 1.11.3
- slf4j: 1.7.10 to 1.7.25

Updated the following plugin versions:

- maven-compiler-plugin: 3.0 to 3.7.0
- maven-source-plugin: 2.4 to 3.0.1
- maven-surefire-plugin: 2.14 to 2.20.1